### PR TITLE
Add channelUpdate event

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -268,6 +268,9 @@ export class Client extends EventEmitter {
 			case GatewayDispatchEvents.ChannelCreate:
 				this.emit("channelCreate", this._handleChannelPayload(payload));
 				break;
+			case GatewayDispatchEvents.ChannelUpdate:
+				this.emit("channelUpdate", this._handleChannelPayload(payload));
+				break;
 			default:
 				break;
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface Attachment {
  */
 export interface ClientEvents {
 	channelCreate: [channel: AnyGuildChannel];
+	channelUpdate: [channel: AnyGuildChannel];
 	error: [error: Error];
 	ready: [];
 	resumed: [];


### PR DESCRIPTION
Added channelUpdate event, this event will need an actual rewrite in the future, where it will also have the `oldChannel` object, so people can do some logic behind it and get which property has changed and which not.